### PR TITLE
Add Trendshift badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![npm version](https://badge.fury.io/js/claude-code-collective.svg)](https://badge.fury.io/js/claude-code-collective)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+<a href="https://trendshift.io/repositories/15208" target="_blank"><img src="https://trendshift.io/api/badge/repositories/15208" alt="vanzan01%2Fclaude-code-sub-agent-collective | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
 **Experimental NPX installer for TDD-focused AI agents**
 
 This installs a collection of AI agents designed for Test-Driven Development and rapid prototyping. It's experimental, opinionated, and I built it to speed up my own MVP development work.


### PR DESCRIPTION
### Motivation
- Display the provided Trendshift repository badge in the project README to surface the Trendshift repository link and badge near the top of the document.

### Description
- Inserted the provided Trendshift HTML badge snippet into `README.md` directly below the existing npm and MIT badges.

### Testing
- No automated runtime tests were needed for this documentation-only change; confirmed the README now contains the inserted badge snippet.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5bc6b434883229662fa54a3fed3a5)